### PR TITLE
fix: wait for namespace to become Active before deploying ArgoCD app

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -128,9 +128,9 @@ func CreateNamespace(ctx context.Context, clientset kubernetes.Interface, namesp
 	// Check if namespace already exists
 	_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
-		// Namespace already exists
+		// Namespace already exists, but wait for it to be Active
 		logger.Info("Namespace '%s' already exists.", namespace)
-		return nil
+		return WaitForNamespaceActive(ctx, clientset, namespace)
 	}
 
 	if !apierrors.IsNotFound(err) {
@@ -151,7 +151,7 @@ func CreateNamespace(ctx context.Context, clientset kubernetes.Interface, namesp
 		if apierrors.IsAlreadyExists(err) {
 			// Race condition: namespace was created between Get and Create
 			logger.Info("Namespace '%s' created concurrently.", namespace)
-			return nil
+			return WaitForNamespaceActive(ctx, clientset, namespace)
 		}
 		logger.Error("Error creating namespace %s: %v", namespace, err)
 		return fmt.Errorf("error creating namespace %s: %w", namespace, err)


### PR DESCRIPTION
## Summary
- Add `WaitForNamespaceActive` function to poll namespace status until it reaches the `Active` phase
- Update `CreateNamespace` to call `WaitForNamespaceActive` after creation, ensuring the namespace is fully ready before the CLI proceeds to deploy the ArgoCD Application
- Prevents race conditions where ArgoCD sync fails because the target namespace is not yet ready

## Test plan
- [ ] Unit tests pass (`task test:unit`)
- [ ] Build succeeds (`task build`)
- [ ] Manual testing: run `kubeasy challenge start <slug>` and verify no sync failures

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)