### PR TITLE
fix: ensure WaitForNamespaceActive is called in all CreateNamespace p…

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -128,9 +128,9 @@ func CreateNamespace(ctx context.Context, clientset kubernetes.Interface, namesp
 	// Check if namespace already exists
 	_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
-		// Namespace already exists
+		// Namespace already exists, but wait for it to be Active
 		logger.Info("Namespace '%s' already exists.", namespace)
-		return nil
+		return WaitForNamespaceActive(ctx, clientset, namespace)
 	}
 
 	if !apierrors.IsNotFound(err) {
@@ -151,7 +151,7 @@ func CreateNamespace(ctx context.Context, clientset kubernetes.Interface, namesp
 		if apierrors.IsAlreadyExists(err) {
 			// Race condition: namespace was created between Get and Create
 			logger.Info("Namespace '%s' created concurrently.", namespace)
-			return nil
+			return WaitForNamespaceActive(ctx, clientset, namespace)
 		}
 		logger.Error("Error creating namespace %s: %v", namespace, err)
 		return fmt.Errorf("error creating namespace %s: %w", namespace, err)


### PR DESCRIPTION
…aths

Address code review feedback from PR #91:

1. Fix missing wait in "already exists" path - When a namespace already exists, we now wait for it to become Active instead of returning immediately. This prevents race conditions if the namespace exists but hasn't reached Active status yet.

2. Fix missing wait in race condition path - When a namespace is created concurrently (AlreadyExists error during Create), we now wait for it to become Active instead of returning immediately.

3. Add comprehensive tests:
   - Test for namespace transitioning from empty phase to Active
   - Test for CreateNamespace waiting when namespace already exists
   - Test for CreateNamespace handling race conditions properly