### PR TITLE
chore(ci): support scoped conventional commits in GoReleaser changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -104,19 +104,19 @@ changelog:
       - Merge branch
   groups:
     - title: "🚀 Features"
-      regexp: "^feat:"
+      regexp: '^feat(\(.+\))?:'
       order: 0
     - title: "🐛 Bug Fixes"
-      regexp: "^fix:"
+      regexp: '^fix(\(.+\))?:'
       order: 1
     - title: "📚 Documentation"
-      regexp: "^docs:"
+      regexp: '^docs(\(.+\))?:'
       order: 2
     - title: "🔧 Improvements"
-      regexp: "^refactor:|^perf:|^style:"
+      regexp: '^(refactor|perf|style)(\(.+\))?:'
       order: 3
     - title: "🧰 Maintenance"
-      regexp: "^chore:"
+      regexp: '^chore(\(.+\))?:'
       order: 4
     - title: "Others"
       order: 999

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `kubeasy-cli` is a command-line tool built with Go and Cobra that helps developers learn Kubernetes through practical challenges. It manages local Kind clusters, deploys challenges via OCI artifacts, and validates solutions using a **CLI-based validation system** (as of v2.0.0).
 
+## Commit & PR Conventions
+
+Commits and PR titles **must** follow [Conventional Commits](https://www.conventionalcommits.org/) with an optional scope:
+
+```
+<type>(<scope>): <description>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `refactor`, `perf`, `style`, `test`, `ci`, `chore`.
+
+Examples:
+- `feat: add cluster status command`
+- `fix(deploy): handle missing namespace`
+- `chore(deps): bump kyverno to v1.13`
+
+This convention is used by GoReleaser to generate the changelog.
+
 ## Documentation
 
 Comprehensive documentation is available in the `docs/` folder:


### PR DESCRIPTION
## Summary
- Fix GoReleaser changelog group regexes to match scoped conventional commits (e.g. `feat(api):`, `fix(deploy):`) in addition to unscoped ones
- Document commit and PR conventions in CLAUDE.md

## Test plan
- [ ] Verify GoReleaser changelog groups correctly categorize scoped commits like `feat(api): add endpoint`
- [ ] Verify unscoped commits like `feat: add feature` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)