### PR TITLE
feat(dev): add --watch-interval flag to dev validate and dev test

### DIFF
--- a/cmd/dev_test_cmd.go
+++ b/cmd/dev_test_cmd.go
@@ -72,6 +72,10 @@ Use --json for structured JSON output (useful for CI).`,
 			ui.Section(fmt.Sprintf("Validating Dev Challenge: %s", challengeSlug))
 		}
 
+		if devTestWatch && devTestWatchInterval <= 0 {
+			return fmt.Errorf("--watch-interval must be a positive duration (e.g. 5s, 1m)")
+		}
+
 		if devTestWatch {
 			header := fmt.Sprintf("Validating Dev Challenge: %s (watch mode)", challengeSlug)
 			return devutils.TickerWatchLoop(cmd.Context(), devTestWatchInterval, header, func() {

--- a/cmd/dev_validate.go
+++ b/cmd/dev_validate.go
@@ -58,6 +58,10 @@ Use --json for structured JSON output (useful for CI).`,
 			return err
 		}
 
+		if devValidateWatch && devValidateWatchInterval <= 0 {
+			return fmt.Errorf("--watch-interval must be a positive duration (e.g. 5s, 1m)")
+		}
+
 		if devValidateWatch {
 			header := fmt.Sprintf("Validating Dev Challenge: %s (watch mode)", challengeSlug)
 			return devutils.TickerWatchLoop(cmd.Context(), devValidateWatchInterval, header, func() {


### PR DESCRIPTION
## Summary

- Adds `--watch-interval` / `-i` duration flag (default `5s`) to `dev validate` and `dev test`
- Replaces hardcoded `5*time.Second` in `TickerWatchLoop` calls with the user-supplied value
- Fully backward-compatible: existing `--watch` usage keeps the 5s default

Fixes #165

## Test plan

- [ ] `./bin/kubeasy dev validate <slug> --watch` behaves identically to before (5s interval)
- [ ] `./bin/kubeasy dev validate <slug> --watch --watch-interval 15s` polls every 15s
- [ ] `./bin/kubeasy dev test <slug> --watch -i 30s` polls every 30s
- [ ] `task test:unit` passes
- [ ] `task lint` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)