### PR TITLE
feat(ui): add CI-friendly plain text output mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func init() {
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kubeasy-cli.yaml)")
 
-	rootCmd.PersistentFlags().BoolVar(&noSpinner, "no-spinner", false, "Disable spinner animations (plain text output, useful for CI/non-interactive environments)")
+	rootCmd.PersistentFlags().BoolVar(&noSpinner, "no-spinner", false, "Force plain text output (spinners are disabled automatically when stdout is not a TTY)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pterm/pterm"
@@ -16,7 +17,8 @@ func SetCIMode(v bool) {
 	ciMode = v
 }
 
-// Spinner creates and starts a spinner with the given text
+// Spinner creates and starts a spinner with the given text.
+// Note: does not respect ciMode — use WaitMessage or TimedSpinner for CI-safe output.
 func Spinner(text string) (*pterm.SpinnerPrinter, error) {
 	spinner, err := pterm.DefaultSpinner.Start(text)
 	if err != nil {
@@ -147,7 +149,8 @@ func KeyValue(key, value string) {
 	pterm.Printf("%s %s\n", pterm.LightCyan(key+":"), value)
 }
 
-// MultiSpinner manages multiple spinners for parallel tasks
+// MultiSpinner manages multiple spinners for parallel tasks.
+// Note: does not respect ciMode — use WaitMessage or TimedSpinner for CI-safe output.
 type MultiSpinner struct {
 	spinners map[string]*pterm.SpinnerPrinter
 }
@@ -202,7 +205,7 @@ func WaitMessage(message string, fn func() error) error {
 		fmt.Printf("• %s...\n", message)
 		err := fn()
 		if err != nil {
-			fmt.Printf("✗ %s\n", message)
+			fmt.Fprintf(os.Stderr, "✗ %s: %v\n", message, err)
 			return err
 		}
 		fmt.Printf("✓ %s\n", message)
@@ -232,7 +235,7 @@ func TimedSpinner(message string, fn func() error) error {
 		err := fn()
 		elapsed := time.Since(start).Round(time.Second)
 		if err != nil {
-			fmt.Printf("✗ %s (failed after %s)\n", message, elapsed)
+			fmt.Fprintf(os.Stderr, "✗ %s (failed after %s): %v\n", message, elapsed, err)
 			return err
 		}
 		fmt.Printf("✓ %s (completed in %s)\n", message, elapsed)


### PR DESCRIPTION
## Summary

- Auto-détecte l'absence de TTY (CI, pipes) et désactive les spinners automatiquement
- Ajoute un flag persistant `--no-spinner` pour forcer le mode texte brut
- En mode CI, `WaitMessage` et `TimedSpinner` affichent du texte simple (`•`, `✓`, `✗`) au lieu des animations qui produisaient des centaines de lignes en environnement non-interactif

## Before / After

**Before (CI output) :**
```
▀  Creating kind cluster 'kubeasy' (Kubernetes 1.35.0) (0s)
 ▀ Creating kind cluster 'kubeasy' (Kubernetes 1.35.0) (0s)
 ▄ Creating kind cluster 'kubeasy' (Kubernetes 1.35.0) (0s)
...
```

**After (CI output) :**
```
• Creating kind cluster 'kubeasy' (Kubernetes 1.35.0)...
✓ Creating kind cluster 'kubeasy' (Kubernetes 1.35.0) (completed in 19s)
```

## Test plan

- [ ] Vérifier que les spinners fonctionnent toujours normalement dans un terminal interactif
- [ ] Vérifier la sortie CI en lançant `kubeasy setup 2>&1 | cat` (pipe = pas de TTY)
- [ ] Vérifier le flag explicite : `kubeasy --no-spinner setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)