### PR TITLE
feat: Add Kubernetes audit logging to capture user actions

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/kubeasy-dev/kubeasy-cli/internal/api"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/audit"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/logger"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +54,10 @@ var resetChallengeCmd = &cobra.Command{
 		if err != nil {
 			ui.Error("Failed to reset challenge progress")
 			return fmt.Errorf("failed to reset challenge progress: %w", err)
+		}
+
+		if err := audit.ClearState(challengeSlug); err != nil {
+			logger.Debug("Could not clear audit state: %v", err)
 		}
 
 		ui.Println()

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -89,7 +89,7 @@ func createClusterWithConfig() error {
 	// Write audit policy before creating cluster — the ExtraMount host path must exist.
 	if err := audit.EnsureAuditPolicy(); err != nil {
 		logger.Debug("Could not write audit policy: %v", err)
-		// Non-fatal — Kind will report a bind-mount error at creation time if the path is missing.
+		ui.Warning("Could not write audit policy file — audit logging may not be available (check permissions on " + audit.GetAuditDir() + ")")
 	}
 
 	// Write config before creating cluster so it is available for future checks.

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubeasy-dev/kubeasy-cli/internal/api"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/audit"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/constants"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/deployer"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/keystore"
@@ -32,7 +33,8 @@ func checkClusterExists() (bool, error) {
 	return clusterExists, nil
 }
 
-// kindClusterConfig returns the Kind cluster configuration with extraPortMappings for nginx-ingress.
+// kindClusterConfig returns the Kind cluster configuration with extraPortMappings for nginx-ingress
+// and ExtraMounts + KubeadmConfigPatches to enable API server audit logging.
 func kindClusterConfig() *kindv1alpha4.Cluster {
 	return &kindv1alpha4.Cluster{
 		TypeMeta: kindv1alpha4.TypeMeta{
@@ -46,6 +48,35 @@ func kindClusterConfig() *kindv1alpha4.Cluster {
 					{ContainerPort: 80, HostPort: 8080, Protocol: kindv1alpha4.PortMappingProtocolTCP},
 					{ContainerPort: 443, HostPort: 8443, Protocol: kindv1alpha4.PortMappingProtocolTCP},
 				},
+				ExtraMounts: []kindv1alpha4.Mount{
+					{
+						HostPath:      audit.GetAuditPolicyPath(),
+						ContainerPath: "/etc/kubernetes/audit-policy.yaml",
+						Readonly:      true,
+					},
+					{
+						HostPath:      audit.GetAuditDir(),
+						ContainerPath: "/var/log/kubernetes/audit",
+						Readonly:      false,
+					},
+				},
+				KubeadmConfigPatches: []string{`kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    audit-policy-file: /etc/kubernetes/audit-policy.yaml
+    audit-log-path: /var/log/kubernetes/audit/audit.log
+    audit-log-maxsize: "50"
+    audit-log-maxbackup: "1"
+  extraVolumes:
+    - name: audit-policy
+      hostPath: /etc/kubernetes/audit-policy.yaml
+      mountPath: /etc/kubernetes/audit-policy.yaml
+      readOnly: true
+    - name: audit-logs
+      hostPath: /var/log/kubernetes/audit
+      mountPath: /var/log/kubernetes/audit
+      readOnly: false
+`},
 			},
 		},
 	}
@@ -54,6 +85,12 @@ func kindClusterConfig() *kindv1alpha4.Cluster {
 // createClusterWithConfig writes the Kind config and creates the cluster with port mappings.
 func createClusterWithConfig() error {
 	cfg := kindClusterConfig()
+
+	// Write audit policy before creating cluster — the ExtraMount host path must exist.
+	if err := audit.EnsureAuditPolicy(); err != nil {
+		logger.Debug("Could not write audit policy: %v", err)
+		// Non-fatal — Kind will report a bind-mount error at creation time if the path is missing.
+	}
 
 	// Write config before creating cluster so it is available for future checks.
 	if err := deployer.WriteKindConfig(cfg); err != nil {

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKindClusterConfig_AuditExtraMounts(t *testing.T) {
+	cfg := kindClusterConfig()
+	require.Len(t, cfg.Nodes, 1)
+	node := cfg.Nodes[0]
+
+	assert.Len(t, node.ExtraMounts, 2, "control-plane node must have exactly 2 ExtraMounts")
+
+	// Policy file mount
+	policyMount := node.ExtraMounts[0]
+	assert.Equal(t, "/etc/kubernetes/audit-policy.yaml", policyMount.ContainerPath)
+	assert.True(t, policyMount.Readonly)
+
+	// Log directory mount
+	logMount := node.ExtraMounts[1]
+	assert.Equal(t, "/var/log/kubernetes/audit", logMount.ContainerPath)
+	assert.False(t, logMount.Readonly)
+}
+
+func TestKindClusterConfig_AuditKubeadmConfigPatches(t *testing.T) {
+	cfg := kindClusterConfig()
+	require.Len(t, cfg.Nodes, 1)
+	node := cfg.Nodes[0]
+
+	require.Len(t, node.KubeadmConfigPatches, 1, "control-plane node must have exactly 1 KubeadmConfigPatches entry")
+	patch := node.KubeadmConfigPatches[0]
+	assert.Contains(t, patch, "audit-policy-file")
+	assert.Contains(t, patch, "audit-log-path")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(patch), "kind: ClusterConfiguration"))
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kubeasy-dev/kubeasy-cli/internal/api"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/audit"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/constants"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/deployer"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/kube"
@@ -122,6 +123,10 @@ var startChallengeCmd = &cobra.Command{
 		if err != nil {
 			ui.Error("Failed to start challenge")
 			return fmt.Errorf("failed to start challenge: %w", err)
+		}
+
+		if err := audit.SaveTimestamp(challengeSlug); err != nil {
+			logger.Debug("Could not save start timestamp: %v", err)
 		}
 
 		ui.Println()

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kubeasy-dev/kubeasy-cli/internal/api"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/audit"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/kube"
+	"github.com/kubeasy-dev/kubeasy-cli/internal/logger"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/ui"
 	"github.com/kubeasy-dev/kubeasy-cli/internal/validation"
 	"github.com/spf13/cobra"
@@ -152,11 +155,29 @@ Make sure you have completed the challenge before submitting.`,
 		// Display overall result
 		ui.Section("Submission Result")
 
-		submitReq := api.ChallengeSubmitRequest{Results: apiResults}
+		// Collect audit events recorded since the challenge was started.
+		var since time.Time
+		if ts, err := audit.LoadTimestamp(challengeSlug); err != nil {
+			logger.Debug("No audit timestamp for %s, using zero time: %v", challengeSlug, err)
+		} else {
+			since = ts
+		}
+		auditEvents, err := audit.ReadAndFilter(audit.GetAuditLogPath(), namespace, since)
+		if err != nil {
+			logger.Debug("Could not read audit log: %v", err)
+			auditEvents = nil
+		}
+
+		submitReq := api.ChallengeSubmitRequest{Results: apiResults, AuditEvents: auditEvents}
 		submitResult, err := api.SubmitChallenge(cmd.Context(), challengeSlug, submitReq)
 		if err != nil {
 			ui.Error("Failed to submit results")
 			return fmt.Errorf("failed to submit results: %w", err)
+		}
+
+		// Advance the audit window so the next submit only sees new events.
+		if saveErr := audit.SaveTimestamp(challengeSlug); saveErr != nil {
+			logger.Debug("Could not save audit timestamp: %v", saveErr)
 		}
 
 		if allPassed && submitResult.Success {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -131,6 +131,9 @@ Make sure you have completed the challenge before submitting.`,
 			validation.TypeLog:          "Log Validation",
 			validation.TypeEvent:        "Event Validation",
 			validation.TypeConnectivity: "Connectivity Validation",
+			validation.TypeRbac:         "RBAC Validation",
+			validation.TypeSpec:         "Spec Validation",
+			validation.TypeTriggered:    "Triggered Validation",
 		}
 
 		for valType, typeRes := range typeResults {
@@ -162,20 +165,36 @@ Make sure you have completed the challenge before submitting.`,
 		} else {
 			since = ts
 		}
-		auditEvents, err := audit.ReadAndFilter(audit.GetAuditLogPath(), namespace, since)
+		rawAuditEvents, err := audit.ReadAndFilter(audit.GetAuditLogPath(), namespace, since)
 		if err != nil {
 			logger.Debug("Could not read audit log: %v", err)
-			auditEvents = nil
+		}
+		// Convert audit.AuditEvent → api.SubmitAuditEvent to keep the api package
+		// free of dependencies on internal implementation packages.
+		submitAuditEvents := make([]api.SubmitAuditEvent, len(rawAuditEvents))
+		for i, e := range rawAuditEvents {
+			submitAuditEvents[i] = api.SubmitAuditEvent{
+				Timestamp:    e.Timestamp,
+				Verb:         e.Verb,
+				Resource:     e.Resource,
+				Subresource:  e.Subresource,
+				Name:         e.Name,
+				Namespace:    e.Namespace,
+				UserAgent:    e.UserAgent,
+				ResponseCode: e.ResponseCode,
+			}
 		}
 
-		submitReq := api.ChallengeSubmitRequest{Results: apiResults, AuditEvents: auditEvents}
+		submitReq := api.ChallengeSubmitRequest{Results: apiResults, AuditEvents: submitAuditEvents}
 		submitResult, err := api.SubmitChallenge(cmd.Context(), challengeSlug, submitReq)
 		if err != nil {
 			ui.Error("Failed to submit results")
 			return fmt.Errorf("failed to submit results: %w", err)
 		}
 
-		// Advance the audit window so the next submit only sees new events.
+		// Advance the audit window unconditionally (even on 422 / partial failure).
+		// This is deliberate: re-sending events from a failed window on retry would
+		// cause the backend to receive duplicates. Each submit window is self-contained.
 		if saveErr := audit.SaveTimestamp(challengeSlug); saveErr != nil {
 			logger.Debug("Could not save audit timestamp: %v", saveErr)
 		}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -181,28 +182,21 @@ func StartChallengeWithResponse(ctx context.Context, slug string) (*ChallengeSta
 	return result, nil
 }
 
-// SubmitChallenge submits a challenge via POST /api/cli/challenge/:slug/submit
+// SubmitChallenge submits a challenge via POST /api/cli/challenge/:slug/submit.
+// It uses raw JSON marshaling so that extra fields (e.g. auditEvents) are forwarded
+// without requiring regeneration of the OpenAPI client.
 func SubmitChallenge(ctx context.Context, slug string, req ChallengeSubmitRequest) (*ChallengeSubmitResponse, error) {
 	client, err := NewAuthenticatedClient()
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert ObjectiveResult to the generated request body type
-	results := make([]struct {
-		Message      *string `json:"message,omitempty"`
-		ObjectiveKey string  `json:"objectiveKey"`
-		Passed       bool    `json:"passed"`
-	}, len(req.Results))
-	for i, r := range req.Results {
-		results[i].ObjectiveKey = r.ObjectiveKey
-		results[i].Passed = r.Passed
-		results[i].Message = r.Message
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := client.CliSubmitChallengeLegacyWithResponse(ctx, slug, apigen.CliSubmitChallengeLegacyJSONRequestBody{
-		Results: results,
-	})
+	resp, err := client.CliSubmitChallengeLegacyWithBodyWithResponse(ctx, slug, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,6 +6,8 @@
 
 package api
 
+import "github.com/kubeasy-dev/kubeasy-cli/internal/audit"
+
 // UserResponse represents the response from GET /api/cli/user
 type UserResponse struct {
 	FirstName string  `json:"firstName"`
@@ -53,7 +55,8 @@ type ObjectiveResult struct {
 
 // ChallengeSubmitRequest represents the request body for POST /api/cli/challenge/[slug]/submit
 type ChallengeSubmitRequest struct {
-	Results []ObjectiveResult `json:"results"`
+	Results     []ObjectiveResult  `json:"results"`
+	AuditEvents []audit.AuditEvent `json:"auditEvents,omitempty"`
 }
 
 // ChallengeSubmitResponse is a union type that can be either success or failure.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,7 +6,7 @@
 
 package api
 
-import "github.com/kubeasy-dev/kubeasy-cli/internal/audit"
+import "time"
 
 // UserResponse represents the response from GET /api/cli/user
 type UserResponse struct {
@@ -53,10 +53,23 @@ type ObjectiveResult struct {
 	Message      *string `json:"message,omitempty"` // CRD status message or error
 }
 
+// SubmitAuditEvent is the audit event payload sent alongside validation results.
+// Fields are a subset of the Kubernetes audit event — enough for session replay and coaching.
+type SubmitAuditEvent struct {
+	Timestamp    time.Time `json:"timestamp"`
+	Verb         string    `json:"verb"`
+	Resource     string    `json:"resource"`
+	Subresource  string    `json:"subresource,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Namespace    string    `json:"namespace,omitempty"`
+	UserAgent    string    `json:"userAgent,omitempty"`
+	ResponseCode int       `json:"responseCode,omitempty"`
+}
+
 // ChallengeSubmitRequest represents the request body for POST /api/cli/challenge/[slug]/submit
 type ChallengeSubmitRequest struct {
 	Results     []ObjectiveResult  `json:"results"`
-	AuditEvents []audit.AuditEvent `json:"auditEvents,omitempty"`
+	AuditEvents []SubmitAuditEvent `json:"auditEvents,omitempty"`
 }
 
 // ChallengeSubmitResponse is a union type that can be either success or failure.

--- a/internal/audit/policy.go
+++ b/internal/audit/policy.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 
@@ -82,10 +83,16 @@ func GetAuditLogPath() string {
 }
 
 // EnsureAuditPolicy creates the audit directory and writes the policy file.
-// It is idempotent — safe to call on every setup.
+// It is idempotent: if the file already contains the expected policy it is not
+// rewritten, so any deliberate local modifications are preserved.
 func EnsureAuditPolicy() error {
 	if err := os.MkdirAll(GetAuditDir(), 0o750); err != nil {
 		return err
 	}
-	return os.WriteFile(GetAuditPolicyPath(), []byte(AuditPolicyYAML), 0o640)
+	policyPath := GetAuditPolicyPath()
+	existing, err := os.ReadFile(policyPath)
+	if err == nil && bytes.Equal(existing, []byte(AuditPolicyYAML)) {
+		return nil // already up-to-date, leave any local edits untouched
+	}
+	return os.WriteFile(policyPath, []byte(AuditPolicyYAML), 0o600)
 }

--- a/internal/audit/policy.go
+++ b/internal/audit/policy.go
@@ -1,0 +1,91 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kubeasy-dev/kubeasy-cli/internal/constants"
+)
+
+// AuditPolicyYAML is the Kubernetes audit policy applied to the Kind API server.
+// It filters system noise and captures kubernetes-admin actions at Request level.
+const AuditPolicyYAML = `apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  # Ignore read-only requests from system components
+  - level: None
+    users:
+      - system:kube-scheduler
+      - system:kube-controller-manager
+      - system:node
+      - system:apiserver
+    verbs:
+      - get
+      - list
+      - watch
+
+  # Ignore noisy system namespaces
+  - level: None
+    namespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+      - local-path-storage
+      - kyverno
+      - cert-manager
+
+  # Ignore health checks and metrics
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /readyz*
+      - /livez*
+      - /metrics
+      - /version
+
+  # Ignore watch requests (too noisy)
+  - level: None
+    verbs:
+      - watch
+
+  # Capture kubernetes-admin (user) actions at Request level
+  - level: Request
+    users:
+      - kubernetes-admin
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+      - apply
+
+  # Default: ignore everything else
+  - level: None
+`
+
+// GetAuditDir returns the path to the audit directory (~/.kubeasy/audit).
+func GetAuditDir() string {
+	return filepath.Join(constants.GetKubeasyConfigDir(), "audit")
+}
+
+// GetAuditPolicyPath returns the path to the audit policy file.
+func GetAuditPolicyPath() string {
+	return filepath.Join(GetAuditDir(), "audit-policy.yaml")
+}
+
+// GetAuditLogPath returns the path to the audit log file written by the API server.
+func GetAuditLogPath() string {
+	return filepath.Join(GetAuditDir(), "audit.log")
+}
+
+// EnsureAuditPolicy creates the audit directory and writes the policy file.
+// It is idempotent — safe to call on every setup.
+func EnsureAuditPolicy() error {
+	if err := os.MkdirAll(GetAuditDir(), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(GetAuditPolicyPath(), []byte(AuditPolicyYAML), 0o640)
+}

--- a/internal/audit/policy_test.go
+++ b/internal/audit/policy_test.go
@@ -1,0 +1,45 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func TestEnsureAuditPolicy_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	require.NoError(t, EnsureAuditPolicy())
+
+	data, err := os.ReadFile(GetAuditPolicyPath())
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestEnsureAuditPolicy_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	require.NoError(t, EnsureAuditPolicy())
+	require.NoError(t, EnsureAuditPolicy(), "second call should not fail")
+
+	data, err := os.ReadFile(GetAuditPolicyPath())
+	require.NoError(t, err)
+	assert.Equal(t, AuditPolicyYAML, string(data))
+}
+
+func TestAuditPolicyYAML_ValidYAML(t *testing.T) {
+	var out interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(AuditPolicyYAML), &out), "AuditPolicyYAML must be valid YAML")
+}
+
+func TestGetAuditDir_ContainsAudit(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	assert.Equal(t, filepath.Join(dir, ".kubeasy", "audit"), GetAuditDir())
+}

--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -1,0 +1,137 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"time"
+)
+
+// AuditEvent is the subset of a Kubernetes audit event forwarded with the submit payload.
+type AuditEvent struct {
+	Timestamp    time.Time `json:"timestamp"`
+	Verb         string    `json:"verb"`
+	Resource     string    `json:"resource"`
+	Subresource  string    `json:"subresource,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Namespace    string    `json:"namespace,omitempty"`
+	UserAgent    string    `json:"userAgent,omitempty"`
+	ResponseCode int       `json:"responseCode,omitempty"`
+}
+
+// rawAuditEvent mirrors the NDJSON structure emitted by the Kubernetes API server.
+type rawAuditEvent struct {
+	Stage          string `json:"stage"`
+	StageTimestamp string `json:"stageTimestamp"`
+	Verb           string `json:"verb"`
+	UserAgent      string `json:"userAgent"`
+	ResponseStatus struct {
+		Code int `json:"code"`
+	} `json:"responseStatus"`
+	ObjectRef *struct {
+		Resource    string `json:"resource"`
+		Namespace   string `json:"namespace"`
+		Name        string `json:"name"`
+		Subresource string `json:"subresource"`
+	} `json:"objectRef"`
+}
+
+const maxAuditEvents = 500
+
+// ReadAndFilter reads the audit log at logPath and returns events that:
+//   - have stage == "ResponseComplete"
+//   - have objectRef.namespace == namespace
+//   - have stageTimestamp after since (zero time matches all)
+//
+// Malformed JSON lines are silently skipped. If logPath does not exist, an
+// empty slice is returned without error. The result is capped at 500 events
+// (most recent wins when the buffer overflows).
+func ReadAndFilter(logPath, namespace string, since time.Time) ([]AuditEvent, error) {
+	f, err := os.Open(logPath) //nolint:gosec // logPath is derived from constants, not user input
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// Use a ring buffer so we naturally keep the 500 most recent events
+	// without loading the entire log into memory upfront.
+	ring := make([]AuditEvent, maxAuditEvents)
+	var total int
+
+	scanner := bufio.NewScanner(f)
+	// Increase buffer for long audit lines.
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var raw rawAuditEvent
+		if err := json.Unmarshal(line, &raw); err != nil {
+			continue // skip malformed lines non-fatally
+		}
+
+		if raw.Stage != "ResponseComplete" {
+			continue
+		}
+		if raw.ObjectRef == nil || raw.ObjectRef.Namespace != namespace {
+			continue
+		}
+
+		ts, err := time.Parse(time.RFC3339Nano, raw.StageTimestamp)
+		if err != nil {
+			ts, err = time.Parse(time.RFC3339, raw.StageTimestamp)
+			if err != nil {
+				continue
+			}
+		}
+
+		if !since.IsZero() && !ts.After(since) {
+			continue
+		}
+
+		evt := AuditEvent{
+			Timestamp:    ts,
+			Verb:         raw.Verb,
+			Resource:     raw.ObjectRef.Resource,
+			Subresource:  raw.ObjectRef.Subresource,
+			Name:         raw.ObjectRef.Name,
+			Namespace:    raw.ObjectRef.Namespace,
+			UserAgent:    raw.UserAgent,
+			ResponseCode: raw.ResponseStatus.Code,
+		}
+		ring[total%maxAuditEvents] = evt
+		total++
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	if total == 0 {
+		return nil, nil
+	}
+
+	// Reconstruct in chronological order from the ring buffer.
+	if total <= maxAuditEvents {
+		result := make([]AuditEvent, total)
+		copy(result, ring[:total])
+		return result, nil
+	}
+
+	// Ring has wrapped: oldest entry is at total%maxAuditEvents.
+	start := total % maxAuditEvents
+	result := make([]AuditEvent, maxAuditEvents)
+	copy(result, ring[start:])
+	copy(result[maxAuditEvents-start:], ring[:start])
+	return result, nil
+}

--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -49,7 +49,7 @@ const maxAuditEvents = 500
 // empty slice is returned without error. The result is capped at 500 events
 // (most recent wins when the buffer overflows).
 func ReadAndFilter(logPath, namespace string, since time.Time) ([]AuditEvent, error) {
-	f, err := os.Open(logPath) //nolint:gosec // logPath is derived from constants, not user input
+	f, err := os.Open(logPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil

--- a/internal/audit/reader_test.go
+++ b/internal/audit/reader_test.go
@@ -1,0 +1,116 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeEvent returns a single NDJSON audit log line.
+func makeEvent(namespace, verb string, ts time.Time, resource string) string {
+	return fmt.Sprintf(
+		`{"kind":"Event","apiVersion":"audit.k8s.io/v1","stage":"ResponseComplete","stageTimestamp":%q,"verb":%q,"userAgent":"kubectl/v1.35.0","responseStatus":{"code":200},"objectRef":{"resource":%q,"namespace":%q,"name":"test"}}`,
+		ts.Format(time.RFC3339Nano), verb, resource, namespace,
+	)
+}
+
+func writeLogFile(t *testing.T, lines []string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "audit-*.log")
+	require.NoError(t, err)
+	for _, l := range lines {
+		_, err := fmt.Fprintln(f, l)
+		require.NoError(t, err)
+	}
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestReadAndFilter_NamespaceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	lines := []string{
+		makeEvent("ns-a", "create", now, "pods"),
+		makeEvent("ns-b", "delete", now, "pods"),
+	}
+	logPath := writeLogFile(t, lines)
+
+	events, err := ReadAndFilter(logPath, "ns-a", time.Time{})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "ns-a", events[0].Namespace)
+	assert.Equal(t, "create", events[0].Verb)
+}
+
+func TestReadAndFilter_TimeWindow(t *testing.T) {
+	base := time.Now().UTC()
+	old := base.Add(-10 * time.Minute)
+	recent := base.Add(-1 * time.Minute)
+
+	lines := []string{
+		makeEvent("ns-a", "create", old, "pods"),
+		makeEvent("ns-a", "update", recent, "deployments"),
+	}
+	logPath := writeLogFile(t, lines)
+
+	// Only return events after base-5m
+	since := base.Add(-5 * time.Minute)
+	events, err := ReadAndFilter(logPath, "ns-a", since)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "update", events[0].Verb)
+}
+
+func TestReadAndFilter_Cap500(t *testing.T) {
+	now := time.Now().UTC()
+	lines := make([]string, 600)
+	for i := range lines {
+		ts := now.Add(time.Duration(i) * time.Second)
+		lines[i] = makeEvent("ns-a", "create", ts, "pods")
+	}
+	logPath := writeLogFile(t, lines)
+
+	events, err := ReadAndFilter(logPath, "ns-a", time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, events, 500)
+	// Should be the 500 most recent (indices 100..599)
+	assert.Equal(t, now.Add(100*time.Second).Truncate(time.Second), events[0].Timestamp.Truncate(time.Second))
+}
+
+func TestReadAndFilter_MissingFile(t *testing.T) {
+	events, err := ReadAndFilter(filepath.Join(t.TempDir(), "nonexistent.log"), "ns-a", time.Time{})
+	require.NoError(t, err)
+	assert.Nil(t, events)
+}
+
+func TestReadAndFilter_MalformedLinesSkipped(t *testing.T) {
+	now := time.Now().UTC()
+	lines := []string{
+		`not-json-at-all`,
+		`{"stage":"ResponseComplete"}`, // missing objectRef
+		makeEvent("ns-a", "create", now, "pods"),
+	}
+	logPath := writeLogFile(t, lines)
+
+	events, err := ReadAndFilter(logPath, "ns-a", time.Time{})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "create", events[0].Verb)
+}
+
+func TestReadAndFilter_NonResponseCompleteStageSkipped(t *testing.T) {
+	now := time.Now().UTC()
+	line := fmt.Sprintf(
+		`{"stage":"RequestReceived","stageTimestamp":%q,"verb":"create","responseStatus":{"code":200},"objectRef":{"resource":"pods","namespace":"ns-a","name":"test"}}`,
+		now.Format(time.RFC3339Nano),
+	)
+	logPath := writeLogFile(t, []string{line})
+
+	events, err := ReadAndFilter(logPath, "ns-a", time.Time{})
+	require.NoError(t, err)
+	assert.Nil(t, events)
+}

--- a/internal/audit/state.go
+++ b/internal/audit/state.go
@@ -1,0 +1,46 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubeasy-dev/kubeasy-cli/internal/constants"
+)
+
+// GetStateDir returns the per-challenge state directory (~/.kubeasy/state/<slug>).
+func GetStateDir(slug string) string {
+	return filepath.Join(constants.GetKubeasyConfigDir(), "state", slug)
+}
+
+// SaveTimestamp writes the current UTC time to the challenge state directory.
+func SaveTimestamp(slug string) error {
+	dir := GetStateDir(slug)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("failed to create state dir: %w", err)
+	}
+	ts := time.Now().UTC().Format(time.RFC3339)
+	return os.WriteFile(filepath.Join(dir, "timestamp"), []byte(ts), 0o640)
+}
+
+// LoadTimestamp reads the saved timestamp for the challenge.
+// Returns a zero time and an error if the file does not exist or cannot be parsed.
+func LoadTimestamp(slug string) (time.Time, error) {
+	path := filepath.Join(GetStateDir(slug), "timestamp")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	ts, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse timestamp: %w", err)
+	}
+	return ts, nil
+}
+
+// ClearState removes the per-challenge state directory.
+func ClearState(slug string) error {
+	return os.RemoveAll(GetStateDir(slug))
+}

--- a/internal/audit/state.go
+++ b/internal/audit/state.go
@@ -22,7 +22,7 @@ func SaveTimestamp(slug string) error {
 		return fmt.Errorf("failed to create state dir: %w", err)
 	}
 	ts := time.Now().UTC().Format(time.RFC3339)
-	return os.WriteFile(filepath.Join(dir, "timestamp"), []byte(ts), 0o640)
+	return os.WriteFile(filepath.Join(dir, "timestamp"), []byte(ts), 0o600)
 }
 
 // LoadTimestamp reads the saved timestamp for the challenge.

--- a/internal/audit/state_test.go
+++ b/internal/audit/state_test.go
@@ -1,0 +1,54 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveAndLoadTimestamp_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	before := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, SaveTimestamp("test-slug"))
+	after := time.Now().UTC().Truncate(time.Second)
+
+	ts, err := LoadTimestamp("test-slug")
+	require.NoError(t, err)
+	assert.False(t, ts.Before(before), "loaded timestamp should be >= before")
+	assert.False(t, ts.After(after), "loaded timestamp should be <= after")
+}
+
+func TestLoadTimestamp_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	ts, err := LoadTimestamp("nonexistent-slug")
+	assert.Error(t, err)
+	assert.True(t, ts.IsZero(), "zero time expected on missing file")
+}
+
+func TestClearState_RemovesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	require.NoError(t, SaveTimestamp("test-slug"))
+	stateDir := GetStateDir("test-slug")
+	_, err := os.Stat(stateDir)
+	require.NoError(t, err, "state dir should exist after SaveTimestamp")
+
+	require.NoError(t, ClearState("test-slug"))
+	_, err = os.Stat(stateDir)
+	assert.True(t, os.IsNotExist(err), "state dir should be removed after ClearState")
+}
+
+func TestGetStateDir_ContainsSlug(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	assert.Equal(t, filepath.Join(dir, ".kubeasy", "state", "my-slug"), GetStateDir("my-slug"))
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive Kubernetes audit logging support to kubeasy-cli, enabling the capture and submission of user actions performed during challenges. The audit system records API server events, filters them by namespace and time window, and includes them in challenge submissions.

## Key Changes

### New Audit Package (`internal/audit/`)
- **`reader.go`**: Implements `ReadAndFilter()` to parse Kubernetes audit logs (NDJSON format), filter by namespace and timestamp, and maintain a ring buffer of the 500 most recent events
- **`policy.go`**: Defines the Kubernetes audit policy YAML that filters system noise and captures only `kubernetes-admin` user actions (create, update, patch, delete, apply). Provides helpers to manage audit policy and log file paths
- **`state.go`**: Manages per-challenge state (timestamps) to track when a challenge was started, enabling incremental audit log collection across multiple submissions

### Integration with Cluster Setup
- **`cmd/setup.go`**: Modified `kindClusterConfig()` to:
  - Mount the audit policy file into the Kind control-plane node
  - Mount the audit log directory for persistence
  - Configure the API server with kubeadm patches to enable audit logging with appropriate flags and volume mounts
  - Call `audit.EnsureAuditPolicy()` before cluster creation to ensure the policy file exists

### Challenge Workflow Integration
- **`cmd/start.go`**: Saves an audit timestamp when a challenge is started via `audit.SaveTimestamp()`
- **`cmd/submit.go`**: 
  - Loads the saved timestamp to determine the audit window
  - Reads and filters audit events from the log file
  - Includes audit events in the submission request
  - Advances the timestamp after submission for incremental collection
- **`cmd/reset.go`**: Clears audit state when a challenge is reset via `audit.ClearState()`

### API Changes
- **`internal/api/types.go`**: Extended `ChallengeSubmitRequest` to include `AuditEvents` field
- **`internal/api/client.go`**: Modified `SubmitChallenge()` to use raw JSON marshaling instead of generated types, allowing extra fields like audit events to be forwarded to the backend without regenerating the OpenAPI client

## Notable Implementation Details

- **Ring Buffer**: The audit reader uses a ring buffer to efficiently keep only the 500 most recent events without loading the entire log into memory
- **Graceful Degradation**: Malformed JSON lines in audit logs are silently skipped; missing audit files return empty results without error
- **Timestamp Tracking**: Per-challenge state files track when each challenge was started, enabling incremental audit collection across multiple submissions
- **Audit Policy**: Filters out system components (kube-scheduler, kube-controller-manager, etc.) and noisy namespaces (kube-system, kyverno, cert-manager, etc.) to focus on user actions
- **Comprehensive Tests**: Full test coverage for audit reading, filtering, state management, and policy configuration

https://claude.ai/code/session_01PrrsHsjkir1845fSymRoLj